### PR TITLE
bug fixes

### DIFF
--- a/code/04_1_4/main.tf
+++ b/code/04_1_4/main.tf
@@ -2,6 +2,11 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">= 0.47.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 3.0"
     }
   }
   required_version = ">=0.13"
@@ -46,7 +51,7 @@ module "vpc_dev" {
 }
 
 module "test-vm" {
-  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=95c286e"
   env_name        = var.env_name_vm
   network_id      = module.vpc_dev.network_id
   subnet_zones    = [var.test_vm_subnet_zones]

--- a/code/04_1_4/variables.tf
+++ b/code/04_1_4/variables.tf
@@ -19,11 +19,6 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
 
 #***************************
 # Параметры zone&cidr


### PR DESCRIPTION
ilya@anikeev:~/terraform-04/code/04_1_4$ docker run --rm -v $(pwd):/data -t ghcr.io/terraform-linters/tflint
4 issue(s) found:

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on main.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_required_providers.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 49:
  49:   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on main.tf line 66:
  66: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "default_cidr" is declared but not used (terraform_unused_declarations)

  on variables.tf line 22:
  22: variable "default_cidr" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_unused_declarations.md

ilya@anikeev:~/terraform-04/code/04_1_4$ checkov -d /home/ilya/terraform-04/code/04_1_4/
2023-12-22 11:28:55,277 [MainThread  ] [WARNI]  Failed to download module git::https://github.com/udjin10/yandex_compute_instance.git?ref=main:None (for external modules, the --download-external-modules flag is required)
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
[ terraform framework ]: 100%|████████████████████|[9/9], Current File Scanned=vpc/vpc.tf      
[ secrets framework ]: 100%|████████████████████|[7/7], Current File Scanned=/home/ilya/terraform-04/code/04_1_4/vpc/outputs.tf  
[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml

       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.1.42 

terraform scan results:

Passed checks: 0, Failed checks: 1, Skipped checks: 0

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: test-vm
        File: /main.tf:48-64
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision

                48 | module "test-vm" {
                49 |   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
                50 |   env_name        = var.env_name_vm
                51 |   network_id      = module.vpc_dev.network_id
                52 |   subnet_zones    = [var.test_vm_subnet_zones]
                53 |   subnet_ids      = [module.vpc_dev.subnet_id]
                54 |   instance_name   = var.test_vm_instance_name
                55 |   instance_count  = var.test_vm_instance_count
                56 |   image_family    = var.test_vm_image_family
                57 |   public_ip       = var.test_vm_public_ip
                58 |   
                59 |   metadata = {
                60 |       user-data          = data.template_file.cloudinit.rendered
                61 |       serial-port-enable = var.test_vm_serial_port
                62 |   }
                63 | 
                64 | }